### PR TITLE
BOOL-1940: Refactor code to work with Python 3.7

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -16,8 +16,6 @@ ENV PYTHONUNBUFFERED=1
 ENV PATH="${PATH}:/home/tiktoken/.local/bin"
 
 RUN pip3 install --upgrade pip
-RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/home/tiktoken/.local python3 - --version 1.3.2
-RUN poetry config virtualenvs.in-project true
 
 USER tiktoken
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.7.10-slim
+
+# Setup user
+ARG CONTAINER_USER_ID=1000
+RUN getent group ${CONTAINER_USER_ID} || groupadd -g ${CONTAINER_USER_ID} tiktoken
+RUN useradd tiktoken -u ${CONTAINER_USER_ID} -g ${CONTAINER_USER_ID} -o -m -s /shell/bash
+
+WORKDIR /mnt/
+
+# Install packages
+# libmagic1 required for running tests
+RUN apt-get update && apt-get install -y libmagic1 curl git build-essential
+
+# Setup Python
+ENV PYTHONUNBUFFERED=1
+ENV PATH="${PATH}:/home/tiktoken/.local/bin"
+
+RUN pip3 install --upgrade pip
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/home/tiktoken/.local python3 - --version 1.3.2
+RUN poetry config virtualenvs.in-project true
+
+USER tiktoken
+
+# Install Rust (needed for tiktokenizer py dep)
+RUN curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | bash -s - -y
+
+CMD [ "/bin/bash", "-c", "sleep infinity" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+services:
+  tiktoken:
+    build:
+      context: ./
+      dockerfile: dev.Dockerfile
+    volumes:
+      - ./:/mnt
+    restart: always

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = {file = "LICENSE"}
 authors = [{name = "Shantanu Jain"}, {email = "shantanu@openai.com"}]
 dependencies = ["regex>=2022.1.18", "requests>=2.26.0"]
 optional-dependencies = {blobfile = ["blobfile>=2"]}
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 
 [project.urls]
 homepage = "https://github.com/openai/tiktoken"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ changelog = "https://github.com/openai/tiktoken/blob/main/CHANGELOG.md"
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=62.4", "wheel", "setuptools-rust>=1.5.2", "typing_extensions>=4.7.1"]
+requires = ["setuptools>=62.4", "wheel", "setuptools-rust>=1.5.2"]
 
 [tool.cibuildwheel]
 build-frontend = "build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ changelog = "https://github.com/openai/tiktoken/blob/main/CHANGELOG.md"
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=62.4", "wheel", "setuptools-rust>=1.5.2"]
+requires = ["setuptools>=62.4", "wheel", "setuptools-rust>=1.5.2", "typing_extensions>=4.7.1"]
 
 [tool.cibuildwheel]
 build-frontend = "build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [{name = "Shantanu Jain"}, {email = "shantanu@openai.com"}]
-dependencies = ["regex>=2022.1.18", "requests>=2.26.0"]
+dependencies = ["regex>=2022.1.18", "requests>=2.26.0", "typing-extensions>=4.7.1"]
 optional-dependencies = {blobfile = ["blobfile>=2"]}
 requires-python = ">=3.7"
 

--- a/scripts/encode.py
+++ b/scripts/encode.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import argparse
+import tiktoken
+
+def main():
+    # Parse arguments
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "text",
+        help="The input to tokenize",
+    )
+    parser.add_argument(
+        "--model",
+        help="Name of model for which tokens will be generated, changed which encoding is used",
+        default="gpt-3.5-turbo-0613",
+    )
+
+    args = parser.parse_args()
+
+    # Encode
+    encoder = tiktoken.encoding_for_model(args.model)
+
+    encoded = encoder.encode(args.text)
+
+    print(f"Encoded '{args.text}' as '{encoded}'")
+
+if __name__ == '__main__':
+    main()

--- a/tiktoken/core.py
+++ b/tiktoken/core.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import functools
 from concurrent.futures import ThreadPoolExecutor
-from typing import AbstractSet, Collection, Literal, NoReturn, Optional, Union
+from typing import AbstractSet, Collection, NoReturn, Optional, Union
+from typing_extensions import Literal
 
 import regex
 

--- a/tiktoken/core.py
+++ b/tiktoken/core.py
@@ -113,7 +113,8 @@ class Encoding:
         if disallowed_special:
             if not isinstance(disallowed_special, frozenset):
                 disallowed_special = frozenset(disallowed_special)
-            if match := _special_token_regex(disallowed_special).search(text):
+            match = _special_token_regex(disallowed_special).search(text)
+            if match:
                 raise_disallowed_special_token(match.group())
 
         try:
@@ -204,7 +205,8 @@ class Encoding:
         if disallowed_special:
             if not isinstance(disallowed_special, frozenset):
                 disallowed_special = frozenset(disallowed_special)
-            if match := _special_token_regex(disallowed_special).search(text):
+            match = _special_token_regex(disallowed_special).search(text)
+            if match:
                 raise_disallowed_special_token(match.group())
 
         return self._core_bpe.encode_with_unstable(text, allowed_special)
@@ -326,7 +328,6 @@ class Encoding:
     def eot_token(self) -> int:
         return self._special_tokens["<|endoftext|>"]
 
-    @functools.cached_property
     def special_tokens_set(self) -> set[str]:
         return set(self._special_tokens.keys())
 

--- a/tiktoken/core.py
+++ b/tiktoken/core.py
@@ -329,6 +329,7 @@ class Encoding:
     def eot_token(self) -> int:
         return self._special_tokens["<|endoftext|>"]
 
+    @property
     def special_tokens_set(self) -> set[str]:
         return set(self._special_tokens.keys())
 


### PR DESCRIPTION
BOOL-1940

The code path exercised by `scripts/encode.py` now works in Python 3.7.