### PR TITLE
BOOL-1940: made typing-extensions dep looser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [{name = "Shantanu Jain"}, {email = "shantanu@openai.com"}]
-dependencies = ["regex>=2022.1.18", "requests>=2.26.0", "typing-extensions>=4.7.1"]
+dependencies = ["regex>=2022.1.18", "requests>=2.26.0", "typing-extensions>=3.7"]
 optional-dependencies = {blobfile = ["blobfile>=2"]}
 requires-python = ">=3.7"
 


### PR DESCRIPTION
BOOL-1940

This repo fails to install for some of our Python 3.7 projects because they specify a lower version of `typing-extensions`. 